### PR TITLE
Separate fonts for front page and bot

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,17 @@ st.set_page_config(page_title="Reguleringsbot", layout="wide")
 st.markdown(
     """
     <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@400;700&display=swap');
+    :root {
+        --app-font: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+        --front-font: 'Playfair Display', Georgia, 'Times New Roman', serif;
+    }
+    [data-testid=\"stAppViewContainer\"], [data-testid=\"stAppViewContainer\"] * {
+        font-family: var(--app-font) !important;
+    }
+    .front-font, .front-font * {
+        font-family: var(--front-font) !important;
+    }
     .scrollbox {
         max-height: 300px;
         overflow-y: auto;
@@ -94,21 +105,24 @@ if "show_welcome" not in st.session_state:
     st.session_state.show_welcome = True
 
 if st.session_state.show_welcome:
-    st.markdown(
-        """
-        ## 👋 Velkommen til Reguleringsbot!
-        
-        Her er hva du kan gjøre:
-        - **Chat med AI**: Still spørsmål om reguleringsplanen i tekstboksen til høyre.
-        - **Utforsk kartet**: Se reguleringsplaner, boligpriser og bedrifter i Tromsø på kartet.
-        - **Analyser planer**: Få AI-vurdering av om planen følger kommunens mål.
-        - **Foreslå analyser**: Send inn egne analyseforslag i sidepanelet.
-        
-        Trykk på "Lukk" når du er klar til å bruke appen.
-        """
-    )
-    if st.button("Lukk", key="close_welcome"):
-        st.session_state.show_welcome = False
+    with st.container():
+        st.markdown('<div class="front-font">', unsafe_allow_html=True)
+        st.markdown(
+            """
+            ## 👋 Velkommen til Reguleringsbot!
+            
+            Her er hva du kan gjøre:
+            - **Chat med AI**: Still spørsmål om reguleringsplanen i tekstboksen til høyre.
+            - **Utforsk kartet**: Se reguleringsplaner, boligpriser og bedrifter i Tromsø på kartet.
+            - **Analyser planer**: Få AI-vurdering av om planen følger kommunens mål.
+            - **Foreslå analyser**: Send inn egne analyseforslag i sidepanelet.
+            
+            Trykk på "Lukk" når du er klar til å bruke appen.
+            """
+        )
+        if st.button("Lukk", key="close_welcome"):
+            st.session_state.show_welcome = False
+        st.markdown('</div>', unsafe_allow_html=True)
 
 st.title("🏗️ Reguleringsbot – Chat og kart over Tromsø")
 


### PR DESCRIPTION
Implement separate fonts for the welcome page and the main application.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce21cc61-6a80-4ce3-9a39-6e775048a750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce21cc61-6a80-4ce3-9a39-6e775048a750">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

