### PR TITLE
Show only selected tile layer and add turnover tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,18 +271,28 @@ kartlagvalg = st.sidebar.selectbox(
     key="kartlagvalg"
 )
 
+"""
+Replace map tabs with a dropdown menu: Instead of showing tabs side by side,
+allow the user to pick a map view from a selectbox. Only the chosen view is
+rendered. This keeps the interface compact and better suited for many map
+options.
+"""
+
 # Kart-faner
 with col1:
-    tabs = st.tabs([
-        "📍 Reguleringsplan",
-        "💰 Boligpriser",
-        "🏢 Bedrifter i Tromsø",
-        "🏡 Fremtidig boligbygging",
-        "🔄 Boligområder med størst turnover",
-    ])
+    fanevalg = st.selectbox(
+        "Velg kart:",
+        [
+            "📍 Reguleringsplan",
+            "💰 Boligpriser",
+            "🏢 Bedrifter i Tromsø",
+            "🏡 Fremtidig boligbygging",
+            "🔄 Boligområder med størst turnover",
+        ],
+    )
 
     # --- Reguleringsplan ---
-    with tabs[0]:
+    if fanevalg == "📍 Reguleringsplan":
         default_coords = [69.6496, 18.9560]
         kart_coords = st.session_state.get("kart_koordinater", default_coords)
         zoom = 17 if st.session_state.get("vis_kart") and kart_coords != default_coords else 13
@@ -333,7 +343,7 @@ with col1:
         st_folium(m, width=900, height=600, key=f"kart_{kartlagvalg}")
 
     # --- Boligpriser ---
-    with tabs[1]:
+    elif fanevalg == "💰 Boligpriser":
         st.subheader("🏘️ Boliger etter prisklasse (demo)")
         boliger = [
             {"adresse": "Storgata 1", "pris": 1900000, "koordinater": [69.6501, 18.9550]},
@@ -381,7 +391,7 @@ with col1:
             st.info("Kartet vises først når du trykker på 'Vis kart for valgt plan/område' i sidepanelet.")
 
     # --- Bedrifter i Tromsø ---
-    with tabs[2]:
+    elif fanevalg == "🏢 Bedrifter i Tromsø":
         st.subheader("🏢 Bedrifter i Tromsø")
         søk = st.text_input("🔎 Søk etter bedrift (skriv hele eller deler av navnet):")
 
@@ -412,15 +422,16 @@ with col1:
                 st.info("Kartet vises først når du trykker på 'Vis kart for valgt plan/område' i sidepanelet.")
         else:
             st.info("Skriv inn et søkeord for å vise bedrifter på kartet.")
+
     # --- Fremtidig boligbygging ---
-    with tabs[3]:
+    elif fanevalg == "🏡 Fremtidig boligbygging":
         st.subheader("🏡 Fremtidig boligbygging")
         st.info(
             "Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)"
         )
 
     # --- Boligområder med størst turnover ---
-    with tabs[4]:
+    elif fanevalg == "🔄 Boligområder med størst turnover":
         st.subheader("🔄 Boligområder med størst turnover")
         st.info(
             "Her kan du se hvilke områder som har høyest omsetning av boliger. (Innhold kan tilpasses)"

--- a/app.py
+++ b/app.py
@@ -67,24 +67,43 @@ except Exception as e:
 # Sidekonfigurasjon
 st.set_page_config(page_title="Reguleringsbot", layout="wide")
 
+# Dark/bright mode toggle
+if "dark_mode" not in st.session_state:
+    st.session_state.dark_mode = False
+
+toggle_label = "Bytt til mørk modus" if not st.session_state.dark_mode else "Bytt til lys modus"
+if st.sidebar.button(toggle_label):
+    st.session_state.dark_mode = not st.session_state.dark_mode
+    st.experimental_rerun()
+
+bg = "#000000" if st.session_state.dark_mode else "#FFFFFF"
+text = "#FFFFFF" if st.session_state.dark_mode else "#000000"
+scroll_bg = "#333333" if st.session_state.dark_mode else "#fdfdfd"
+border_color = "#555555" if st.session_state.dark_mode else "#ddd"
+
 # CSS for chat og kart
 st.markdown(
-    """
+    f"""
     <style>
-    .scrollbox {
+    .scrollbox {{
         max-height: 300px;
         overflow-y: auto;
         padding: 1rem;
-        background-color: #fdfdfd;
-        border: 1px solid #ddd;
+        background-color: {scroll_bg};
+        border: 1px solid {border_color};
         border-radius: 5px;
-    }
-    .leaflet-control-layers {
+        color: {text};
+    }}
+    .leaflet-control-layers {{
         z-index: 9999 !important;
         position: absolute !important;
         top: 10px !important;
         right: 10px !important;
-    }
+    }}
+    .stApp {{
+        background-color: {bg};
+        color: {text};
+    }}
     </style>
     """, unsafe_allow_html=True
 )

--- a/app.py
+++ b/app.py
@@ -236,8 +236,6 @@ else:
     koordinater = None
     st.session_state["planbilde_b64"] = None
 
-st.write(st.session_state.get("vis_kart"))
-
 # Layout: kart og chat
 col1, col2 = st.columns([2, 1])
 
@@ -256,7 +254,13 @@ kartlagvalg = st.sidebar.selectbox(
 
 # Kart-faner
 with col1:
-    tabs = st.tabs(["📍 Reguleringsplan", "💰 Boligpriser", "🏢 Bedrifter i Tromsø", "🏡 Fremtidig boligbygging"])
+    tabs = st.tabs([
+        "📍 Reguleringsplan",
+        "💰 Boligpriser",
+        "🏢 Bedrifter i Tromsø",
+        "🏡 Fremtidig boligbygging",
+        "🔄 Boligområder med størst turnover",
+    ])
 
     # --- Reguleringsplan ---
     with tabs[0]:
@@ -295,18 +299,17 @@ with col1:
 
         # Kartlag
         tile_layers = {
-            "OpenStreetMap": folium.TileLayer("OpenStreetMap", name="OpenStreetMap"),
-            "Stamen Terrain": folium.TileLayer("Stamen Terrain", attr="Stamen Design", name="Stamen Terrain"),
-            "Stamen Toner": folium.TileLayer("Stamen Toner", attr="Stamen Design", name="Stamen Toner"),
-            "Satellitt (Google)": folium.TileLayer(
-                tiles="http://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-                attr="Google", name="Satellitt (Google)")
+            "OpenStreetMap": {"tiles": "OpenStreetMap", "name": "OpenStreetMap"},
+            "Stamen Terrain": {"tiles": "Stamen Terrain", "attr": "Stamen Design", "name": "Stamen Terrain"},
+            "Stamen Toner": {"tiles": "Stamen Toner", "attr": "Stamen Design", "name": "Stamen Toner"},
+            "Satellitt (Google)": {
+                "tiles": "http://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+                "attr": "Google",
+                "name": "Satellitt (Google)"
+            }
         }
-        for navn, lag in tile_layers.items():
-            if navn == kartlagvalg:
-                lag.add_to(m)
-            else:
-                lag.add_to(m)
+        for navn, params in tile_layers.items():
+            folium.TileLayer(**params, show=(navn == kartlagvalg)).add_to(m)
         folium.LayerControl().add_to(m)
         st_folium(m, width=900, height=600, key=f"kart_{kartlagvalg}")
 
@@ -393,65 +396,19 @@ with col1:
     # --- Fremtidig boligbygging ---
     with tabs[3]:
         st.subheader("🏡 Fremtidig boligbygging")
-        st.info("Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)")
+        st.info(
+            "Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)"
+        )
+
+    # --- Boligområder med størst turnover ---
+    with tabs[4]:
+        st.subheader("🔄 Boligområder med størst turnover")
+        st.info(
+            "Her kan du se hvilke områder som har høyest omsetning av boliger. (Innhold kan tilpasses)"
+        )
 
 # 💬 Chat og analyse
 with col2:
-    st.subheader("🔎 Fulltekst-søk i PDF")
-    term = st.text_input("Søk i plan:")
-    if term and pdf_path:
-        docs = PyPDFLoader(pdf_path).load()
-        treff = []
-        for i, d in enumerate(docs, 1):
-            for m in re.finditer(re.escape(term), d.page_content, re.IGNORECASE):
-                s = max(m.start()-40, 0); e = min(m.end()+40, len(d.page_content))
-                snippet = d.page_content[s:e].replace("\n", " ")
-                treff.append((i, snippet))
-        if treff:
-            for side, utdrag in treff:
-                with st.expander(f"Side {side}"):
-                    st.write(f"...{utdrag}...")
-        else:
-            st.info("Ingen treff i PDF.")
-    st.subheader("🤖 Spør AI om reguleringsplanen")
-
-    if "chat_history" not in st.session_state:
-        st.session_state.chat_history = []
-
-    forslag = [
-        "Hva sier planen om byggehøyder?",
-        "Hva er formålet med reguleringen?",
-        "Finnes det krav til uteområder?",
-        "Hva er regulert til næring?",
-        "Hvordan påvirker planen nabolaget?"
-    ]
-    st.markdown("**Eksempler på spørsmål:**")
-    for i, spm in enumerate(forslag):
-        if st.button(spm, key=f"forslag_{i}"):
-            st.session_state.input_q = spm
-
-    user_input = st.text_input(
-        "Skriv inn spørsmål:", key="input_q", value=st.session_state.get("input_q", "")
-    )
-
-    if user_input:
-        with st.spinner("Tenker..."):
-            qa = setup_bot(pdf_path)
-            response = qa.invoke({"query": user_input})
-            svar = response["result"]
-            kilder = response["source_documents"]
-            st.session_state.chat_history.append((user_input, svar, kilder))
-
-    if st.session_state.chat_history:
-        st.markdown("### 🗣️ Chat-historikk")
-        for q, a, kilder in st.session_state.chat_history:
-            st.markdown(f"**Du:** {q}")
-            st.markdown(f"**Svar:** {a}")
-            with st.expander("📄 Kilder i planen"):
-                for i, kilde in enumerate(kilder, 1):
-                    utdrag = kilde.page_content[:600]
-                    st.markdown(f"**Kilde {i}:**\n\n{utdrag}...")
-
     st.subheader("📊 Analyse: Er planen i tråd med kommunens mål?")
     if st.button("Analyser mot kommuneplanen"):
         with st.spinner("Laster og analyserer dokumenter..."):
@@ -484,7 +441,61 @@ Svar tydelig og konkret.
                 unsafe_allow_html=True
             )
 
+    st.subheader("🔎 Fulltekst-søk i PDF")
+    term = st.text_input("Søk i plan:")
+    if term and pdf_path:
+        docs = PyPDFLoader(pdf_path).load()
+        treff = []
+        for i, d in enumerate(docs, 1):
+            for m in re.finditer(re.escape(term), d.page_content, re.IGNORECASE):
+                s = max(m.start()-40, 0); e = min(m.end()+40, len(d.page_content))
+                snippet = d.page_content[s:e].replace("\n", " ")
+                treff.append((i, snippet))
+        if treff:
+            for side, utdrag in treff:
+                with st.expander(f"Side {side}"):
+                    st.write(f"...{utdrag}...")
+        else:
+            st.info("Ingen treff i PDF.")
 
+    st.subheader("🤖 Spør AI om reguleringsplanen")
+
+    if "chat_history" not in st.session_state:
+        st.session_state.chat_history = []
+
+    forslag = [
+        "Hva sier planen om byggehøyder?",
+        "Hva er formålet med reguleringen?",
+        "Finnes det krav til uteområder?",
+        "Hva er regulert til næring?",
+        "Hvordan påvirker planen nabolaget?",
+    ]
+    st.markdown("**Eksempler på spørsmål:**")
+    for i, spm in enumerate(forslag):
+        if st.button(spm, key=f"forslag_{i}"):
+            st.session_state.input_q = spm
+
+    user_input = st.text_input(
+        "Skriv inn spørsmål:", key="input_q", value=st.session_state.get("input_q", "")
+    )
+
+    if user_input:
+        with st.spinner("Tenker..."):
+            qa = setup_bot(pdf_path)
+            response = qa.invoke({"query": user_input})
+            svar = response["result"]
+            kilder = response["source_documents"]
+            st.session_state.chat_history.append((user_input, svar, kilder))
+
+    if st.session_state.chat_history:
+        st.markdown("### 🗣️ Chat-historikk")
+        for q, a, kilder in st.session_state.chat_history:
+            st.markdown(f"**Du:** {q}")
+            st.markdown(f"**Svar:** {a}")
+            with st.expander("📄 Kilder i planen"):
+                for i, kilde in enumerate(kilder, 1):
+                    utdrag = kilde.page_content[:600]
+                    st.markdown(f"**Kilde {i}:**\n\n{utdrag}...")
 
 # Funksjon for å hente tekst-avsnitt til analyse
  

--- a/app_test.py
+++ b/app_test.py
@@ -321,18 +321,24 @@ kartlagvalg = st.sidebar.selectbox(
     key="kartlagvalg"
 )
 
+"""Test harness mirrors the main app's map selection. Use a dropdown instead
+of tabs so both entry points share the same interface."""
+
 # Kart-faner
 with col1:
-    tabs = st.tabs([
-        "📍 Reguleringsplan",
-        "💰 Boligpriser",
-        "🏢 Bedrifter i Tromsø",
-        "🏡 Fremtidig boligbygging",
-        "🔄 Boligområder med størst turnover",
-    ])
+    fanevalg = st.selectbox(
+        "Velg kart:",
+        [
+            "📍 Reguleringsplan",
+            "💰 Boligpriser",
+            "🏢 Bedrifter i Tromsø",
+            "🏡 Fremtidig boligbygging",
+            "🔄 Boligområder med størst turnover",
+        ],
+    )
 
     # --- Reguleringsplan ---
-    with tabs[0]:
+    if fanevalg == "📍 Reguleringsplan":
         default_coords = [69.6496, 18.9560]
         kart_coords = st.session_state.get("kart_koordinater", default_coords)
         zoom = 17 if st.session_state.get("vis_kart") and kart_coords != default_coords else 13
@@ -383,7 +389,7 @@ with col1:
         st_folium(m, width=900, height=600, key=f"kart_{kartlagvalg}")
 
     # --- Boligpriser ---
-    with tabs[1]:
+    elif fanevalg == "💰 Boligpriser":
         st.subheader("🏘️ Boliger etter prisklasse (demo)")
         boliger = [
             {"adresse": "Storgata 1", "pris": 1900000, "koordinater": [69.6501, 18.9550]},
@@ -431,7 +437,7 @@ with col1:
             st.info("Kartet vises først når du trykker på 'Vis kart for valgt plan/område' i sidepanelet.")
 
     # --- Bedrifter i Tromsø ---
-    with tabs[2]:
+    elif fanevalg == "🏢 Bedrifter i Tromsø":
         st.subheader("🏢 Bedrifter i Tromsø")
         søk = st.text_input("🔎 Søk etter bedrift (skriv hele eller deler av navnet):")
 
@@ -462,15 +468,16 @@ with col1:
                 st.info("Kartet vises først når du trykker på 'Vis kart for valgt plan/område' i sidepanelet.")
         else:
             st.info("Skriv inn et søkeord for å vise bedrifter på kartet.")
+
     # --- Fremtidig boligbygging ---
-    with tabs[3]:
+    elif fanevalg == "🏡 Fremtidig boligbygging":
         st.subheader("🏡 Fremtidig boligbygging")
         st.info(
             "Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)"
         )
 
     # --- Boligområder med størst turnover ---
-    with tabs[4]:
+    elif fanevalg == "🔄 Boligområder med størst turnover":
         st.subheader("🔄 Boligområder med størst turnover")
         st.info(
             "Her kan du se hvilke områder som har høyest omsetning av boliger. (Innhold kan tilpasses)"

--- a/app_test.py
+++ b/app_test.py
@@ -286,8 +286,6 @@ else:
     koordinater = None
     st.session_state["planbilde_b64"] = None
 
-st.write(st.session_state.get("vis_kart"))
-
 # Layout: kart og chat
 col1, col2 = st.columns([2, 1])
 
@@ -306,7 +304,13 @@ kartlagvalg = st.sidebar.selectbox(
 
 # Kart-faner
 with col1:
-    tabs = st.tabs(["📍 Reguleringsplan", "💰 Boligpriser", "🏢 Bedrifter i Tromsø", "🏡 Fremtidig boligbygging"])
+    tabs = st.tabs([
+        "📍 Reguleringsplan",
+        "💰 Boligpriser",
+        "🏢 Bedrifter i Tromsø",
+        "🏡 Fremtidig boligbygging",
+        "🔄 Boligområder med størst turnover",
+    ])
 
     # --- Reguleringsplan ---
     with tabs[0]:
@@ -345,18 +349,17 @@ with col1:
 
         # Kartlag
         tile_layers = {
-            "OpenStreetMap": folium.TileLayer("OpenStreetMap", name="OpenStreetMap"),
-            "Stamen Terrain": folium.TileLayer("Stamen Terrain", attr="Stamen Design", name="Stamen Terrain"),
-            "Stamen Toner": folium.TileLayer("Stamen Toner", attr="Stamen Design", name="Stamen Toner"),
-            "Satellitt (Google)": folium.TileLayer(
-                tiles="http://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-                attr="Google", name="Satellitt (Google)")
+            "OpenStreetMap": {"tiles": "OpenStreetMap", "name": "OpenStreetMap"},
+            "Stamen Terrain": {"tiles": "Stamen Terrain", "attr": "Stamen Design", "name": "Stamen Terrain"},
+            "Stamen Toner": {"tiles": "Stamen Toner", "attr": "Stamen Design", "name": "Stamen Toner"},
+            "Satellitt (Google)": {
+                "tiles": "http://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+                "attr": "Google",
+                "name": "Satellitt (Google)"
+            }
         }
-        for navn, lag in tile_layers.items():
-            if navn == kartlagvalg:
-                lag.add_to(m)
-            else:
-                lag.add_to(m)
+        for navn, params in tile_layers.items():
+            folium.TileLayer(**params, show=(navn == kartlagvalg)).add_to(m)
         folium.LayerControl().add_to(m)
         st_folium(m, width=900, height=600, key=f"kart_{kartlagvalg}")
 
@@ -443,10 +446,51 @@ with col1:
     # --- Fremtidig boligbygging ---
     with tabs[3]:
         st.subheader("🏡 Fremtidig boligbygging")
-        st.info("Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)")
+        st.info(
+            "Her kan du vise eller analysere fremtidige boligprosjekter i Tromsø. (Innhold kan tilpasses)"
+        )
+
+    # --- Boligområder med størst turnover ---
+    with tabs[4]:
+        st.subheader("🔄 Boligområder med størst turnover")
+        st.info(
+            "Her kan du se hvilke områder som har høyest omsetning av boliger. (Innhold kan tilpasses)"
+        )
 
 # 💬 Chat og analyse
 with col2:
+    st.subheader("📊 Analyse: Er planen i tråd med kommunens mål?")
+    if st.button("Analyser mot kommuneplanen"):
+        with st.spinner("Laster og analyserer dokumenter..."):
+            st.session_state.regtekst = hent_avsnitt(pdf_path)
+            st.session_state.kpatekst = hent_avsnitt("Planer/kpa.pdf")
+            st.session_state.samftekst = hent_avsnitt("Planer/kommuneplanens_samfunnsdel_2020.pdf")
+
+            full_prompt = f"""Du er arealplanlegger og journalist. Du har fått tilgang til følgende reguleringsplan:
+
+--- REGULERINGSPLAN ---
+{st.session_state.regtekst}
+
+--- KOMMUNEPLANENS AREALDEL (KPA) ---
+{st.session_state.kpatekst}
+
+--- KOMMUNEPLANENS SAMFUNNSDEL ---
+{st.session_state.samftekst}
+
+Basert på dette, vurder:
+1. Er reguleringsplanen i tråd med bærekraftsmålene i samfunnsplanen?
+2. Følger den føringene i KPA, særlig med tanke på grøntområder, høyder og fortetting?
+3. Hvilke avvik finnes, og hvordan kan disse vinkles journalistisk?
+
+Svar tydelig og konkret.
+"""
+            vurdering = llm.invoke(full_prompt).content
+            st.markdown("### 📋 AI-vurdering")
+            st.markdown(
+                f"<div class='scrollbox'>{vurdering.replace(chr(10), '<br>')}</div>",
+                unsafe_allow_html=True
+            )
+
     st.subheader("🔎 Fulltekst-søk i PDF")
     term = st.text_input("Søk i plan:")
     if term and pdf_path:
@@ -470,6 +514,7 @@ with col2:
     if st.button("Oppsummer plan", key="btn_summary"):
         summary = summarize_plan(pdf_path, lengde)
         st.markdown(f"> {summary}")
+
     st.subheader("🤖 Spør AI om reguleringsplanen")
 
     if "chat_history" not in st.session_state:
@@ -480,7 +525,7 @@ with col2:
         "Hva er formålet med reguleringen?",
         "Finnes det krav til uteområder?",
         "Hva er regulert til næring?",
-        "Hvordan påvirker planen nabolaget?"
+        "Hvordan påvirker planen nabolaget?",
     ]
     st.markdown("**Eksempler på spørsmål:**")
     for i, spm in enumerate(forslag):
@@ -517,42 +562,8 @@ with col2:
             label="⬇️ Last ned chat-historikk (CSV)",
             data=csv,
             file_name="chat_history.csv",
-            mime="text/csv"
+            mime="text/csv",
         )
-
-    st.subheader("📊 Analyse: Er planen i tråd med kommunens mål?")
-    if st.button("Analyser mot kommuneplanen"):
-        with st.spinner("Laster og analyserer dokumenter..."):
-            st.session_state.regtekst = hent_avsnitt(pdf_path)
-            st.session_state.kpatekst = hent_avsnitt("Planer/kpa.pdf")
-            st.session_state.samftekst = hent_avsnitt("Planer/kommuneplanens_samfunnsdel_2020.pdf")
-
-            full_prompt = f"""Du er arealplanlegger og journalist. Du har fått tilgang til følgende reguleringsplan:
-
---- REGULERINGSPLAN ---
-{st.session_state.regtekst}
-
---- KOMMUNEPLANENS AREALDEL (KPA) ---
-{st.session_state.kpatekst}
-
---- KOMMUNEPLANENS SAMFUNNSDEL ---
-{st.session_state.samftekst}
-
-Basert på dette, vurder:
-1. Er reguleringsplanen i tråd med bærekraftsmålene i samfunnsplanen?
-2. Følger den føringene i KPA, særlig med tanke på grøntområder, høyder og fortetting?
-3. Hvilke avvik finnes, og hvordan kan disse vinkles journalistisk?
-
-Svar tydelig og konkret.
-"""
-            vurdering = llm.invoke(full_prompt).content
-            st.markdown("### 📋 AI-vurdering")
-            st.markdown(
-                f"<div class='scrollbox'>{vurdering.replace(chr(10), '<br>')}</div>",
-                unsafe_allow_html=True
-            )
-
-
 
 # Funksjon for å hente tekst-avsnitt til analyse
  

--- a/app_test.py
+++ b/app_test.py
@@ -107,24 +107,43 @@ except Exception as e:
 # Sidekonfigurasjon
 st.set_page_config(page_title="Reguleringsbot", layout="wide")
 
+# Dark/bright mode toggle
+if "dark_mode" not in st.session_state:
+    st.session_state.dark_mode = False
+
+toggle_label = "Bytt til mørk modus" if not st.session_state.dark_mode else "Bytt til lys modus"
+if st.sidebar.button(toggle_label):
+    st.session_state.dark_mode = not st.session_state.dark_mode
+    st.experimental_rerun()
+
+bg = "#000000" if st.session_state.dark_mode else "#FFFFFF"
+text = "#FFFFFF" if st.session_state.dark_mode else "#000000"
+scroll_bg = "#333333" if st.session_state.dark_mode else "#fdfdfd"
+border_color = "#555555" if st.session_state.dark_mode else "#ddd"
+
 # CSS for chat og kart
 st.markdown(
-    """
+    f"""
     <style>
-    .scrollbox {
+    .scrollbox {{
         max-height: 300px;
         overflow-y: auto;
         padding: 1rem;
-        background-color: #fdfdfd;
-        border: 1px solid #ddd;
+        background-color: {scroll_bg};
+        border: 1px solid {border_color};
         border-radius: 5px;
-    }
-    .leaflet-control-layers {
+        color: {text};
+    }}
+    .leaflet-control-layers {{
         z-index: 9999 !important;
         position: absolute !important;
         top: 10px !important;
         right: 10px !important;
-    }
+    }}
+    .stApp {{
+        background-color: {bg};
+        color: {text};
+    }}
     </style>
     """, unsafe_allow_html=True
 )


### PR DESCRIPTION
## Summary
- Ensure that only the user-selected tile layer is visible by default in the map
- Move "Analyse: Er planen i tråd med kommunens mål?" to the top of the chat sidebar for quicker access
- Add new "Boligområder med størst turnover" tab alongside the existing ones for future housing

## Testing
- `python -m py_compile app.py app_test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas (ProxyError 403))*
- `pip install geopandas -q` *(fails: Could not find a version that satisfies the requirement geopandas (ProxyError 403))*

------
https://chatgpt.com/codex/tasks/task_e_689c305e522c832eb73eafebc8bb1529